### PR TITLE
Temporary bugfix for Magento 2.4 - 2.5

### DIFF
--- a/Observer/OrderSaveAfter.php
+++ b/Observer/OrderSaveAfter.php
@@ -81,7 +81,8 @@ final class OrderSaveAfter implements ObserverInterface {
 			]));
 		}
 		$z->setMethod(Z::POST);
-		$z->setRawData(json_encode($p, JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES|JSON_UNESCAPED_UNICODE));
+		// TODO - fails with canceled orders for some reason
+		$z->setRawData(json_encode($p, JSON_UNESCAPED_SLASHES|JSON_UNESCAPED_UNICODE));
 		return $z->request()->getBody();
 	}
 }


### PR DESCRIPTION
Magento stores on version 2.4+ running the master version of the [Magento 2 Webhook Module](https://github.com/stock2shop/magento2_module_webhook/), will fail with the following error when trying to send orders to Stock2Shop:
```
Could not decode json: Syntax error, malformed JSON
```

This PR resolves this issue for most order statuses, except cancelled orders (that we know of).

Reference: https://github.com/stock2shop/app/issues/1922